### PR TITLE
Make internals of main project visible to tests project.

### DIFF
--- a/src/Lecs/AssemblyInfo.cs
+++ b/src/Lecs/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Lecs.Tests")]


### PR DESCRIPTION
Add `AssemblyInfo.cs` file for defining assembly wide attributes and add `[assembly:InternalsVisibleTo("Lecs.Tests")]`