### PR TITLE
Add configuration for 'dotnet-test-explorer' plugin to vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,7 @@
 {
+  // Common plugins
+  "dotnet-test-explorer.testProjectPath": "src/Lecs.Tests/Lecs.Tests.csproj",
+
   // Search settings
   "search.useIgnoreFiles": false,
   "search.exclude": {


### PR DESCRIPTION
Usefully plugin for viewing test results in a visual way in the ide

Extension: `formulahendry.dotnet-test-explorer`