### PR TITLE
Test coverage analysis

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
   "tasks": [
     {
       "label": "clean",
-      "command": "dotnet clean src/Lecs.sln",
+      "command": "./ci/clean.sh",
       "type": "shell",
       "group": "build",
       "problemMatcher": "$msCompile"
@@ -13,7 +13,7 @@
     {
       "label": "build",
       "dependsOn": "clean",
-      "command": "dotnet build src/Lecs.sln",
+      "command": "./ci/build.sh",
       "type": "shell",
       "group": {
         "kind": "build",
@@ -24,7 +24,7 @@
     {
       "label": "test",
       "dependsOn": "build",
-      "command": "dotnet test src/Lecs.Tests/Lecs.Tests.csproj",
+      "command": "./ci/test.sh",
       "type": "shell",
       "group": "build",
       "problemMatcher": "$msCompile"
@@ -32,7 +32,7 @@
     {
       "label": "benchmark",
       "dependsOn": "build",
-      "command": "dotnet run -c Release -p src/Lecs.Benchmark/Lecs.Benchmark.csproj --exporters GitHub --artifacts ./artifacts/benchmark",
+      "command": "./ci/benchmark.sh",
       "type": "shell",
       "group": "build",
       "problemMatcher": "$msCompile"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: clean build test benchmark
 default: build
 
+install:
+	./ci/install.sh
+
 clean:
 	./ci/clean.sh
 

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,14 @@
 default: build
 
 clean:
-	dotnet clean src/Lecs.sln
+	./ci/clean.sh
 
 build: clean
-	dotnet build src/Lecs.sln
+	./ci/build.sh
 
 test: build
-	dotnet test src/Lecs.Tests/Lecs.Tests.csproj
+	./ci/test.sh
 
 filter=Lecs.Benchmark.*
 benchmark: build
-	rm -rf ./artifacts/benchmark
-	dotnet run -c Release -p src/Lecs.Benchmark/Lecs.Benchmark.csproj \
-	--filter $(filter) --exporters GitHub --artifacts ./artifacts/benchmark
+	FILTER=$(filter) ./ci/benchmark.sh

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -7,21 +7,18 @@ pool:
 
 variables:
   sdk: '3.0.100-preview-009812'
-  buildConfiguration: 'Release'
-  sln: './src/Lecs.sln'
-  tests: './src/Lecs.Tests/Lecs.Tests.csproj'
 
 steps:
 - task: DotNetCoreInstaller@0
   inputs:
     version: $(sdk)
-- script: dotnet build --configuration $(buildConfiguration) /p:TreatWarningsAsErrors=true /warnaserror $(sln)
-  displayName: 'dotnet build $(buildConfiguration)'
-- script: dotnet test $(tests) --logger "xunit;LogFileName=TestResults.xml"
-  displayName: 'dotnet test'
+- script: ./ci/build_release.sh
+  displayName: 'Build'
+- script: ./ci/test.sh
+  displayName: 'Test'
 - task: PublishTestResults@2
-  displayName: 'publish test results to azure pipelines'
+  displayName: 'Publish test results to azure pipelines'
   inputs:
     testResultsFormat: 'xUnit'
-    testResultsFiles: '**/TestResults.xml'
+    testResultsFiles: 'artifacts/xunit.results.xml'
   condition: always()

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -6,27 +6,30 @@ pool:
   vmImage: 'Ubuntu 16.04'
 
 variables:
-  sdk: '3.0.100-preview-009812'
+  PATH: '/home/vsts/.dotnet:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
 
 steps:
-- task: DotNetCoreInstaller@0
-  inputs:
-    version: $(sdk)
+- script: ./ci/install.sh
+  displayName: 'Install dependencies'
+
 - script: ./ci/build_release.sh
   displayName: 'Build'
+
 - script: ./ci/test.sh
   displayName: 'Test'
+
 - task: PublishTestResults@2
   displayName: 'Publish test results to azure pipelines'
   inputs:
     testResultsFormat: 'xUnit'
     testResultsFiles: '$(System.DefaultWorkingDirectory)/artifacts/xunit.results.xml'
   condition: always()
+
 - task: PublishCodeCoverageResults@1
   displayName: 'Publish test coverage results to azure pipelines'
   inputs:
     codeCoverageTool: 'cobertura'
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/artifacts/coverage.cobertura.xml'
-    reportDirectory: '$(System.DefaultWorkingDirectory)/artifacts'
+    reportDirectory: '$(System.DefaultWorkingDirectory)/artifacts/coverage_report'
     failIfCoverageEmpty: true
   condition: always()

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -20,5 +20,13 @@ steps:
   displayName: 'Publish test results to azure pipelines'
   inputs:
     testResultsFormat: 'xUnit'
-    testResultsFiles: 'artifacts/xunit.results.xml'
+    testResultsFiles: '$(System.DefaultWorkingDirectory)/artifacts/xunit.results.xml'
+  condition: always()
+- task: PublishCodeCoverageResults@1
+  displayName: 'Publish test coverage results to azure pipelines'
+  inputs:
+    codeCoverageTool: 'cobertura'
+    summaryFileLocation: '$(System.DefaultWorkingDirectory)/artifacts/coverage.cobertura.xml'
+    reportDirectory: '$(System.DefaultWorkingDirectory)/artifacts'
+    failIfCoverageEmpty: true
   condition: always()

--- a/ci/benchmark.sh
+++ b/ci/benchmark.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+FILTER="${FILTER:-"Lecs.Benchmark.*"}"
+OUTPUT_PATH="./artifacts/benchmark"
+
+# Run benchmark
+dotnet run -c Release -p src/Lecs.Benchmark/Lecs.Benchmark.csproj \
+    --filter $FILTER --exporters GitHub --artifacts $OUTPUT_PATH

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -e
 
+# Diagnostics
+echo "Used tooling: '$(which dotnet)'"
+echo "Installed sdks:"
+dotnet --list-sdks
+echo "";
+
 # Build the solution
 dotnet build src/Lecs.sln

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+# Build the solution
+dotnet build src/Lecs.sln

--- a/ci/build_release.sh
+++ b/ci/build_release.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+# Build the solution in release configuration
+dotnet build --configuration Release /p:TreatWarningsAsErrors=true /warnaserror src/Lecs.sln

--- a/ci/build_release.sh
+++ b/ci/build_release.sh
@@ -1,5 +1,11 @@
 #!/bin/sh
 set -e
 
+# Diagnostics
+echo "Used tooling: '$(which dotnet)'"
+echo "Installed sdks:"
+dotnet --list-sdks
+echo "";
+
 # Build the solution in release configuration
 dotnet build --configuration Release /p:TreatWarningsAsErrors=true /warnaserror src/Lecs.sln

--- a/ci/clean.sh
+++ b/ci/clean.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Delete old artifacts
+rm -rf ./artifacts
+
+# Clean the solution
+dotnet clean src/Lecs.sln

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+SDK_VERSION="3.0.100-preview-009812"
+
+# Install the dotnet core 2.0 sdk
+# We need a 2.x sdk because not all tooling works with 3.0 yet
+echo "Installing core '2.x' sdk"
+curl -sSL https://dot.net/v1/dotnet-install.sh | \
+    bash -s -- -Channel 2.0 -Verbose
+
+# Install the dotnet core 3.0 sdk
+echo "Installing core '$SDK_VERSION' sdk"
+curl -sSL https://dot.net/v1/dotnet-install.sh | \
+    bash -s -- -Version $SDK_VERSION -Verbose

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 COVERAGE_THRESHOLD=75
 TEST_RESULT_PATH="./../../artifacts/xunit.results.xml"
@@ -11,8 +10,11 @@ dotnet test src/Lecs.Tests/Lecs.Tests.csproj \
     --logger "xunit;LogFilePath=$TEST_RESULT_PATH" \
     /p:CollectCoverage=true /p:Include="[Lecs]*" /p:UseSourceLink=true /p:Threshold=$COVERAGE_THRESHOLD \
     /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$COVERAGE_RESULT_PATH
+EXIT_CODE=$?
 
 # Create coverage report
 (cd src/Lecs.Tests && \
     dotnet reportgenerator \
     "-reports:$COVERAGE_RESULT_PATH" "-targetdir:$REPORT_RESULT_PATH" "-reporttypes:HtmlInline_AzurePipelines")
+
+exit $EXIT_CODE

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -3,9 +3,15 @@ set -e
 
 TEST_RESULT_PATH="./../../artifacts/xunit.results.xml"
 COVERAGE_RESULT_PATH="./../../artifacts/coverage.cobertura.xml"
+REPORT_RESULT_PATH="./../../artifacts/coverage_report"
 
 # Run test
 dotnet test src/Lecs.Tests/Lecs.Tests.csproj \
     --logger "xunit;LogFilePath=$TEST_RESULT_PATH" \
     /p:CollectCoverage=true /p:Include="[Lecs]*" /p:UseSourceLink=true \
     /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$COVERAGE_RESULT_PATH
+
+# Create coverage report
+(cd src/Lecs.Tests && \
+    dotnet reportgenerator \
+    "-reports:$COVERAGE_RESULT_PATH" "-targetdir:$REPORT_RESULT_PATH" "-reporttypes:HtmlInline_AzurePipelines")

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+TEST_RESULT_PATH="./../../artifacts/xunit.results.xml"
+COVERAGE_RESULT_PATH="./../../artifacts/coverage.cobertura.xml"
+
+# Run test
+dotnet test src/Lecs.Tests/Lecs.Tests.csproj \
+    --logger "xunit;LogFilePath=$TEST_RESULT_PATH" \
+    /p:CollectCoverage=true /p:Include="[Lecs]*" /p:UseSourceLink=true \
+    /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$COVERAGE_RESULT_PATH

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 
+COVERAGE_THRESHOLD=75
 TEST_RESULT_PATH="./../../artifacts/xunit.results.xml"
 COVERAGE_RESULT_PATH="./../../artifacts/coverage.cobertura.xml"
 REPORT_RESULT_PATH="./../../artifacts/coverage_report"
@@ -8,7 +9,7 @@ REPORT_RESULT_PATH="./../../artifacts/coverage_report"
 # Run test
 dotnet test src/Lecs.Tests/Lecs.Tests.csproj \
     --logger "xunit;LogFilePath=$TEST_RESULT_PATH" \
-    /p:CollectCoverage=true /p:Include="[Lecs]*" /p:UseSourceLink=true \
+    /p:CollectCoverage=true /p:Include="[Lecs]*" /p:UseSourceLink=true /p:Threshold=$COVERAGE_THRESHOLD \
     /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$COVERAGE_RESULT_PATH
 
 # Create coverage report

--- a/src/Lecs.Tests/Lecs.Tests.csproj
+++ b/src/Lecs.Tests/Lecs.Tests.csproj
@@ -40,6 +40,9 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
 
+    <!-- Tools -->
+    <DotNetCliToolReference Include="dotnet-reportgenerator-cli" Version="4.0.5-rc4" />
+
   </ItemGroup>
 
 </Project>

--- a/src/Lecs.Tests/Lecs.Tests.csproj
+++ b/src/Lecs.Tests/Lecs.Tests.csproj
@@ -22,6 +22,12 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="XunitXML.TestLogger" Version="2.0.0" />
 
+    <!-- Test coverage analysis -->
+    <PackageReference Include="coverlet.msbuild" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+
     <!-- Static code analysis -->
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Lecs.Tests/Memory/Mask256Tests.cs
+++ b/src/Lecs.Tests/Memory/Mask256Tests.cs
@@ -9,20 +9,59 @@ namespace Lecs.Tests.Memory
 {
     public sealed class Mask256Tests
     {
-        [AvxFact]
-        public static void Mask256_AsMutable_WorksAsExpected()
+        [Theory]
+        [MemberData(nameof(GetSingleMasksData))]
+        public static void ReadOnlyMask256_Equals_IsEqualToMask256(Mask256 mask, byte elementNumber)
+        {
+            var readOnlyMask = ReadOnlyMask256.Create(elementNumber);
+            Assert.True(readOnlyMask.Equals(in mask));
+            Assert.True(mask.Equals(in readOnlyMask));
+            Assert.Equal(mask.GetHashCode(), readOnlyMask.GetHashCode());
+
+            Assert.True(readOnlyMask.Equals((object)mask));
+            Assert.True(mask.Equals((object)readOnlyMask));
+        }
+
+        [Fact]
+        public static void ReadOnlyMask256_Empty_IsEqualToDefaultMask()
+        {
+            var defaultMask = Mask256.Create();
+            Assert.True(defaultMask.Equals(in ReadOnlyMask256.Empty));
+
+            var readOnlyDefaultMask = default(ReadOnlyMask256);
+            Assert.True(readOnlyDefaultMask.Equals(in ReadOnlyMask256.Empty));
+        }
+
+        [Fact]
+        public static void ReadOnlyMask256_AsMutable_WorksAsExpected()
         {
             var readOnlyMask = ReadOnlyMask256.Create(new byte[] { 31, 63, 95, 127, 159, 191, 223, 255 });
             var mutableMask = readOnlyMask.AsMutable();
             Assert.True(readOnlyMask.Equals(mutableMask));
+            Assert.Equal(readOnlyMask.GetHashCode(), mutableMask.GetHashCode());
         }
 
-        [AvxFact]
+        [Fact]
+        public static void ReadOnlyMask256_Equals_IncorrectTypeIsUnequal()
+        {
+            var floatVal = 1f;
+            Assert.False(ReadOnlyMask256.Empty.Equals(floatVal));
+        }
+
+        [Fact]
+        public static void Mask256_Equals_IncorrectTypeIsUnequal()
+        {
+            var floatVal = 1f;
+            Assert.False(default(Mask256).Equals(floatVal));
+        }
+
+        [Fact]
         public static void Mask256_AsReadOnly_WorksAsExpected()
         {
             var mutableMask = Mask256.Create(new byte[] { 31, 63, 95, 127, 159, 191, 223, 255 });
             var readOnlyMask = mutableMask.AsReadOnly();
             Assert.True(mutableMask.Equals(readOnlyMask));
+            Assert.Equal(mutableMask.GetHashCode(), readOnlyMask.GetHashCode());
         }
 
         [AvxFact]
@@ -33,20 +72,20 @@ namespace Lecs.Tests.Memory
             Assert.False(maskA.NotHasAnyAvx(in maskB));
         }
 
-        [AvxFact]
-        public static void Mask256_NotHasAny_DoesntFindsAny_Avx()
-        {
-            var maskA = Mask256.Create(bit: 100);
-            var maskB = Mask256.Create(new byte[] { 50, 75, 125 });
-            Assert.True(maskA.NotHasAnyAvx(in maskB));
-        }
-
         [Fact]
         public static void Mask256_NotHasAny_FindsAny_Software()
         {
             var maskA = Mask256.Create(bit: 100);
             var maskB = Mask256.Create(new byte[] { 50, 75, 100, 125 });
             Assert.False(maskA.NotHasAnySoftware(in maskB));
+        }
+
+        [AvxFact]
+        public static void Mask256_NotHasAny_DoesntFindsAny_Avx()
+        {
+            var maskA = Mask256.Create(bit: 100);
+            var maskB = Mask256.Create(new byte[] { 50, 75, 125 });
+            Assert.True(maskA.NotHasAnyAvx(in maskB));
         }
 
         [Fact]
@@ -97,20 +136,20 @@ namespace Lecs.Tests.Memory
             Assert.True(maskA.HasAnyAvx(in maskB));
         }
 
-        [AvxFact]
-        public static void Mask256_HasAny_DoesntFindsAny_Avx()
-        {
-            var maskA = Mask256.Create(bit: 100);
-            var maskB = Mask256.Create(new byte[] { 50, 75, 125 });
-            Assert.False(maskA.HasAnyAvx(in maskB));
-        }
-
         [Fact]
         public static void Mask256_HasAny_FindsAny_Software()
         {
             var maskA = Mask256.Create(bit: 100);
             var maskB = Mask256.Create(new byte[] { 50, 75, 100, 125 });
             Assert.True(maskA.HasAnySoftware(in maskB));
+        }
+
+        [AvxFact]
+        public static void Mask256_HasAny_DoesntFindsAny_Avx()
+        {
+            var maskA = Mask256.Create(bit: 100);
+            var maskB = Mask256.Create(new byte[] { 50, 75, 125 });
+            Assert.False(maskA.HasAnyAvx(in maskB));
         }
 
         [Fact]
@@ -236,6 +275,15 @@ namespace Lecs.Tests.Memory
         public static void Mask256_ToString_ExpectedOutput()
         {
             var mask = Mask256.Create(new byte[] { 31, 63, 95, 127, 159, 191, 223, 255 });
+            var expectedString =
+                "0000000000000000000000000000000100000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000100000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000100000000000000000000000000000001";
+            Assert.Equal(expectedString, mask.ToString());
+        }
+
+        [Fact]
+        public static void ReadOnlyMask256_ToString_ExpectedOutput()
+        {
+            var mask = ReadOnlyMask256.Create(new byte[] { 31, 63, 95, 127, 159, 191, 223, 255 });
             var expectedString =
                 "0000000000000000000000000000000100000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000100000000000000000000000000000001000000000000000000000000000000010000000000000000000000000000000100000000000000000000000000000001";
             Assert.Equal(expectedString, mask.ToString());

--- a/src/Lecs.Tests/Memory/Mask256Tests.cs
+++ b/src/Lecs.Tests/Memory/Mask256Tests.cs
@@ -145,11 +145,11 @@ namespace Lecs.Tests.Memory
         {
             var testMask = Mask256.Create();
 
-            testMask.Add(in mask);
+            testMask.AddAvx2(in mask);
             Assert.True(testMask.EqualsAvx2(in mask));
             Assert.True(testMask.HasAllAvx(in mask));
 
-            testMask.Remove(mask);
+            testMask.RemoveAvx2(mask);
             Assert.True(testMask.EqualsAvx2(default(Mask256)));
             Assert.False(testMask.EqualsAvx2(in mask));
             Assert.False(testMask.HasAnyAvx(in mask));
@@ -161,11 +161,11 @@ namespace Lecs.Tests.Memory
         {
             var testMask = Mask256.Create();
 
-            testMask.Add(in mask);
+            testMask.AddAvx(in mask);
             Assert.True(testMask.EqualsAvx(in mask));
             Assert.True(testMask.HasAllAvx(in mask));
 
-            testMask.Remove(mask);
+            testMask.RemoveAvx(mask);
             Assert.True(testMask.EqualsAvx(default(Mask256)));
             Assert.False(testMask.EqualsAvx(in mask));
             Assert.False(testMask.HasAnyAvx(in mask));
@@ -177,11 +177,11 @@ namespace Lecs.Tests.Memory
         {
             var defaultMask = Mask256.Create();
 
-            defaultMask.Add(in mask);
+            defaultMask.AddSoftware(in mask);
             Assert.True(defaultMask.EqualsSoftware(in mask));
             Assert.True(defaultMask.HasAllSoftware(in mask));
 
-            defaultMask.Remove(in mask);
+            defaultMask.RemoveSoftware(in mask);
             Assert.True(defaultMask.EqualsSoftware(default(Mask256)));
             Assert.False(defaultMask.EqualsSoftware(in mask));
             Assert.False(defaultMask.HasAnySoftware(in mask));

--- a/src/Lecs/Lecs.csproj
+++ b/src/Lecs/Lecs.csproj
@@ -9,6 +9,8 @@
     <AssemblyName>Lecs</AssemblyName>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
@@ -28,6 +30,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+
+    <!-- Sourcelink -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
 
   </ItemGroup>
 

--- a/src/Lecs/Memory/Mask256.cs
+++ b/src/Lecs/Memory/Mask256.cs
@@ -33,6 +33,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator ==(in Mask256 a, in Mask256 b) => a.Equals(in b);
 
         /// <summary>
@@ -42,6 +43,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator ==(in Mask256 a, in ReadOnlyMask256 b) => a.Equals(in b);
 
         /// <summary>
@@ -51,6 +53,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are unequal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator !=(in Mask256 a, in Mask256 b) => !a.Equals(in b);
 
         /// <summary>
@@ -60,6 +63,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are unequal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator !=(in Mask256 a, in ReadOnlyMask256 b) => !a.Equals(in b);
 
         /// <summary>
@@ -415,6 +419,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         bool IEquatable<Mask256>.Equals(Mask256 other) => this.Equals(other);
 
         /// <summary>
@@ -423,6 +428,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         bool IEquatable<ReadOnlyMask256>.Equals(ReadOnlyMask256 other) => this.Equals(other);
     }
 }

--- a/src/Lecs/Memory/Mask256.cs
+++ b/src/Lecs/Memory/Mask256.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
@@ -106,6 +107,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if it has all bits, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAll(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -123,6 +125,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if it has all bits, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAll(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -140,6 +143,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if this mask has any bit of the given mask set, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAny(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -157,6 +161,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if this mask has any bit of the given mask set, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAny(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -174,6 +179,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if this mask doesn't have any bit of the given mask set, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool NotHasAny(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -191,6 +197,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if this mask doesn't have any bit of the given mask set, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool NotHasAny(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -207,6 +214,7 @@ namespace Lecs.Memory
         /// Note: Use with 'in' semantics whenever possible to avoid copying data unnecessarily.
         /// </summary>
         /// <param name="other">Other mask containing the bits to set.</param>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public void Add(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -226,6 +234,7 @@ namespace Lecs.Memory
         /// Note: Use with 'in' semantics whenever possible to avoid copying data unnecessarily.
         /// </summary>
         /// <param name="other">Other mask containing the bits to set.</param>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public void Add(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -245,6 +254,7 @@ namespace Lecs.Memory
         /// Note: Use with 'in' semantics whenever possible to avoid copying data unnecessarily.
         /// </summary>
         /// <param name="other">Other mask containing the bits to unset.</param>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public void Remove(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -264,6 +274,7 @@ namespace Lecs.Memory
         /// Note: Use with 'in' semantics whenever possible to avoid copying data unnecessarily.
         /// </summary>
         /// <param name="other">Other mask containing the bits to unset.</param>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public void Remove(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -281,6 +292,7 @@ namespace Lecs.Memory
         /// <summary>
         /// Invert all the bits in this mask.
         /// </summary>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public void Invert()
         {
             fixed (long* dataPointer = this.Data)
@@ -298,6 +310,7 @@ namespace Lecs.Memory
         /// <summary>
         /// Unset all bits in this mask.
         /// </summary>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public void Clear()
         {
             fixed (long* dataPointer = this.Data)
@@ -360,6 +373,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool Equals(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -380,6 +394,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool Equals(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)

--- a/src/Lecs/Memory/ReadOnlyMask256.cs
+++ b/src/Lecs/Memory/ReadOnlyMask256.cs
@@ -1,6 +1,7 @@
 #pragma warning disable SA1600 // Elements must be documented
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Runtime.Intrinsics.X86;
@@ -107,6 +108,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if it has all bits, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAll(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -124,6 +126,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if it has all bits, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAll(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -141,6 +144,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if this mask has any bit of the given mask set, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAny(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -158,6 +162,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if this mask has any bit of the given mask set, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool HasAny(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -174,8 +179,8 @@ namespace Lecs.Memory
         /// Note: Use with 'in' semantics whenever possible to avoid copying data unnecessarily.
         /// </summary>
         /// <param name="other">Mask containing the bits to check.</param>
-        /// <returns>True if this mask doesn't have any bit of the given mask set, otherwise false.
-        /// </returns>
+        /// <returns>True if this mask doesn't have any bit of the given mask set, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool NotHasAny(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -194,6 +199,7 @@ namespace Lecs.Memory
         /// <param name="other">Mask containing the bits to check.</param>
         /// <returns>True if this mask doesn't have any bit of the given mask set, otherwise false.
         /// </returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool NotHasAny(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -256,6 +262,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool Equals(in ReadOnlyMask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)
@@ -276,6 +283,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         public bool Equals(in Mask256 other)
         {
             fixed (long* dataPointerA = this.Data, dataPointerB = other.Data)

--- a/src/Lecs/Memory/ReadOnlyMask256.cs
+++ b/src/Lecs/Memory/ReadOnlyMask256.cs
@@ -40,6 +40,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator ==(in ReadOnlyMask256 a, in ReadOnlyMask256 b) => a.Equals(in b);
 
         /// <summary>
@@ -49,6 +50,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator ==(in ReadOnlyMask256 a, in Mask256 b) => a.Equals(in b);
 
         /// <summary>
@@ -58,6 +60,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are unequal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator !=(in ReadOnlyMask256 a, in ReadOnlyMask256 b) => !a.Equals(in b);
 
         /// <summary>
@@ -67,6 +70,7 @@ namespace Lecs.Memory
         /// <param name="a">Mask to compare.</param>
         /// <param name="b">Mask to compare to.</param>
         /// <returns>True if the masks are unequal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Implemention already tested
         public static bool operator !=(in ReadOnlyMask256 a, in Mask256 b) => !a.Equals(in b);
 
         /// <summary>
@@ -304,6 +308,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         bool IEquatable<ReadOnlyMask256>.Equals(ReadOnlyMask256 other) => this.Equals(other);
 
         /// <summary>
@@ -312,6 +317,7 @@ namespace Lecs.Memory
         /// </summary>
         /// <param name="other">Mask to compare.</param>
         /// <returns>True if equal, otherwise false.</returns>
+        [ExcludeFromCodeCoverage] // Individual implementions already tested separately
         bool IEquatable<Mask256>.Equals(Mask256 other) => this.Equals(other);
     }
 }


### PR DESCRIPTION
Added test coverage analysis and set a minimum test coverage of `75%` (Below that builds will fail).

Coverage can be calculated locally using `make test`, html reports are generated in `./artifacts/coverage_report` and basic stats are printed on each test run. Stats as part of builds can be view in the azure pipeline under `Code Coverage` and under the `Summary` tabs. Note: Haven't found a way yet to make the `Code Coverage` page public yet so currently only members can view it.

Used technologies:
- [`CoverLet`](https://github.com/tonerdo/coverlet)
For the actual coverage generation (exports the results as a `cobertura` file)

- [`ReportGenerator`](https://github.com/danielpalme/ReportGenerator)
For generating html report pages from the `cobertura` file exported from `CoverLet`

- [`SourceLink`](https://github.com/dotnet/sourcelink)
To generate GitHub paths to source files instead of absolute paths on the drive. (Much nicer when viewing on the azure pipeline)


