### PR TITLE
Add more explicit struct layout for 'Mask256' 'ReadOnlyMask256'

### DIFF
--- a/src/Lecs/Memory/Mask256.cs
+++ b/src/Lecs/Memory/Mask256.cs
@@ -21,9 +21,10 @@ namespace Lecs.Memory
     /// Prefer using the methods with 'in' semantics as it avoids copying this (relatively big) struct
     /// unnecessarily.
     /// </remarks>
-    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 32)] // 4 * 8 byte = 32 byte
+    [StructLayout(LayoutKind.Explicit, Size = 32)] // 4 * 8 byte = 32 byte
     public unsafe partial struct Mask256 : IEquatable<Mask256>, IEquatable<ReadOnlyMask256>
     {
+        [FieldOffset(0)]
         internal fixed long Data[4]; // 4 * 64 bit = 256 bit
 
         /// <summary>

--- a/src/Lecs/Memory/ReadOnlyMask256.cs
+++ b/src/Lecs/Memory/ReadOnlyMask256.cs
@@ -20,9 +20,10 @@ namespace Lecs.Memory
     ///
     /// Prefer using the methods with 'in' semantics as it avoids copying this (relatively big) unnecessarily.
     /// </remarks>
-    [StructLayout(LayoutKind.Sequential, Pack = 1, Size = 32)] // 4 * 8 byte = 32 byte
+    [StructLayout(LayoutKind.Explicit, Size = 32)] // 4 * 8 byte = 32 byte
     public unsafe partial struct ReadOnlyMask256 : IEquatable<ReadOnlyMask256>, IEquatable<Mask256>
     {
+        [FieldOffset(0)]
         internal fixed long Data[4]; // 4 * 64 bit = 256 bit
 
         private static ReadOnlyMask256 empty = default(ReadOnlyMask256);


### PR DESCRIPTION
Important because their memory layouts have to be identical for being able to reinterpreting them.